### PR TITLE
Add Docker-based dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ index.css
 # Ignore Jekyll
 .sass-cache/
 .jekyll-metadata
+
+# Ignore VSCode meta files
+.devcontainer

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM jekyll/jekyll
+
+ENV JEKYLL_ENV=docker
+WORKDIR /workspace
+EXPOSE 4000
+
+CMD sh start.sh

--- a/README.md
+++ b/README.md
@@ -11,11 +11,34 @@ We hope that this living playbook will inspire and drive further improvements, b
 
 To submit or request changes, please enter an [issue](https://github.com/Bloom-Works/new-america/issues/new).
 
-## This project runs on Jekyll. To get started:
+## Dev Setup
 
-1. Clone the repo
+### Local
+
+1. Clone the repo and navigate into the base folder
 2. Install Jekyll
 3. Run `jekyll serve --watch --config _config-dev.yml`
 4. Install yarn
 5. Install NPM dependencies `yarn install`
 6. In another terminal, run POSTCSS with `yarn postcss:watch`
+
+### Docker / Visual Studio Code Remote Container
+
+Use these instructions if you need a clean/consistent environment.
+
+1. Clone the repo and navigate into the base folder
+1. Run `docker build -t improveunemployment -f Dockerfile.dev .` (first time only)
+1. Run `docker run -it -p 4000:4000 -v "$(pwd):/workspace" --rm improveunemployment`
+1. Access the site at `https://localhost:4000`
+
+If you need to restart the entire environment, the easiest way is to issue `exit` and re-enter via `docker run...`.
+
+Alternately, you can open a Docker-based dev environment in VSCode with the Remote Development Extension:
+
+1. Open the base folder in VSCode
+1. Execute the `Remote Containers: Open Folder in Container.." and choose `Dockerfile.dev`
+1. From the VSCode embedded terminal, you can execute the following commands:
+1. Run `yarn install && yarn postcss:watch &` (hit `Enter` and this will run in the background, rebuilding CSS after edits)
+1. Run `jekyll serve --watch --config _config-dev.yml`
+1. Click the URL in the log to forward port 4000 to your host machine
+1. Access the site at `https://localhost:4000`

--- a/README.md
+++ b/README.md
@@ -22,23 +22,19 @@ To submit or request changes, please enter an [issue](https://github.com/Bloom-W
 5. Install NPM dependencies `yarn install`
 6. In another terminal, run POSTCSS with `yarn postcss:watch`
 
-### Docker / Visual Studio Code Remote Container
+### Docker / Clean Environment
 
-Use these instructions if you need a clean/consistent environment.
+Use these instructions if you need a clean/consistent environment inside a local Docker container.
 
 1. Clone the repo and navigate into the base folder
-1. Run `docker build -t improveunemployment -f Dockerfile.dev .` (first time only)
+1. Run `docker build -t improveunemployment .` (first time only)
 1. Run `docker run -it -p 4000:4000 -v "$(pwd):/workspace" --rm improveunemployment`
 1. Access the site at `https://localhost:4000`
 
-If you need to restart the entire environment, the easiest way is to issue `exit` and re-enter via `docker run...`.
+Tips:
 
-Alternately, you can open a Docker-based dev environment in VSCode with the Remote Development Extension:
-
-1. Open the base folder in VSCode
-1. Execute the `Remote Containers: Open Folder in Container.." and choose `Dockerfile.dev`
-1. From the VSCode embedded terminal, you can execute the following commands:
-1. Run `yarn install && yarn postcss:watch &` (hit `Enter` and this will run in the background, rebuilding CSS after edits)
-1. Run `jekyll serve --watch --config _config-dev.yml`
-1. Click the URL in the log to forward port 4000 to your host machine
-1. Access the site at `https://localhost:4000`
+- This will reload content, CSS, and config changes live
+- `CTRL`+`C` will stop the process from running
+- If you need to run a Jekyll or Yarn command, launch a Bash terminal:
+    - Docker Desktop: Choose the running image and click `CLI`
+    - Command line: `docker run -it -v "$(pwd):/workspace" --rm improveunemployment bash`

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+yarn install
+yarn postcss:watch &
+jekyll serve --watch --config _config-dev.yml


### PR DESCRIPTION
Adds the ability to run a clean dev environment in Docker, such that this isn't impacted by other projects on one's computer.

Instructions are included in the README.md file, and doesn't impact any existing functionality or the ability to run outside of a container using the existing instructions.