### PR TITLE
Fix local Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jekyll/jekyll
+FROM jekyll/jekyll:4.2.0
 
 ENV JEKYLL_ENV=docker
 WORKDIR /workspace

--- a/start.sh
+++ b/start.sh
@@ -2,5 +2,7 @@
 set -e
 
 yarn install
+yarn build
 yarn postcss:watch &
+jekyll build
 jekyll serve --watch --config _config-dev.yml

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 set -e
 
 yarn install
-yarn build
+yarn postcss:build
 yarn postcss:watch &
 jekyll build
 jekyll serve --watch --config _config-dev.yml


### PR DESCRIPTION
Locks the Docker image to a known version that works (i.e. later versions upgraded Ruby's major version and it breaks things) and adds a few commands to the startup script.

This does not fix problems with deploying the site from GitHub Actions.